### PR TITLE
SPM test target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,8 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+# macOS
+
+.DS_Store
+

--- a/Beeline.xcodeproj/project.pbxproj
+++ b/Beeline.xcodeproj/project.pbxproj
@@ -7,44 +7,74 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		22B3A5F2269DC48000E1E843 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22B3A5F1269DC48000E1E843 /* AppDelegate.swift */; };
-		22B3A5FB269DC48100E1E843 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 22B3A5FA269DC48100E1E843 /* Assets.xcassets */; };
-		22B3A5FE269DC48100E1E843 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 22B3A5FC269DC48100E1E843 /* LaunchScreen.storyboard */; };
-		22B3A608269DCFA500E1E843 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22B3A607269DCFA500E1E843 /* Router.swift */; };
-		22BCBE6F26A29DCB0081CADE /* AppRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BCBE6E26A29DCB0081CADE /* AppRouter.swift */; };
-		22BCBE7226A29F350081CADE /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BCBE7026A29F350081CADE /* ViewController.swift */; };
-		22BCBE7326A29F350081CADE /* ViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 22BCBE7126A29F350081CADE /* ViewController.xib */; };
+		FA37C3E8297C8CCA0079E96C /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22B3A607269DCFA500E1E843 /* Router.swift */; };
+		FA37C3F1297C8CFF0079E96C /* libBeeline.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FA37C3E1297C8CBA0079E96C /* libBeeline.a */; };
+		FA37C3F8297C8D6E0079E96C /* BeelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA37C3F7297C8D6E0079E96C /* BeelineTests.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		FA37C3F2297C8CFF0079E96C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 22B3A5E6269DC48000E1E843 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FA37C3E0297C8CBA0079E96C;
+			remoteInfo = Beeline;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		FA37C3DF297C8CBA0079E96C /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
-		227B686026A719FA0000DD8D /* BeelineExample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = BeelineExample.entitlements; sourceTree = "<group>"; };
-		22B3A5EE269DC48000E1E843 /* BeelineExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BeelineExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		22B3A5F1269DC48000E1E843 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		22B3A5FA269DC48100E1E843 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		22B3A5FD269DC48100E1E843 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		22B3A5FF269DC48100E1E843 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		227B685926A706860000DD8D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		22B3A607269DCFA500E1E843 /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
-		22BCBE6E26A29DCB0081CADE /* AppRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRouter.swift; sourceTree = "<group>"; };
-		22BCBE7026A29F350081CADE /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
-		22BCBE7126A29F350081CADE /* ViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ViewController.xib; sourceTree = "<group>"; };
+		FA37C3E1297C8CBA0079E96C /* libBeeline.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libBeeline.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		FA37C3ED297C8CFF0079E96C /* BeelineTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BeelineTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FA37C3F7297C8D6E0079E96C /* BeelineTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BeelineTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		22B3A5EB269DC48000E1E843 /* Frameworks */ = {
+		FA37C3DE297C8CBA0079E96C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FA37C3EA297C8CFF0079E96C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FA37C3F1297C8CFF0079E96C /* libBeeline.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		227B685626A706860000DD8D /* BeelineTests */ = {
+			isa = PBXGroup;
+			children = (
+				FA37C3F7297C8D6E0079E96C /* BeelineTests.swift */,
+				227B685926A706860000DD8D /* Info.plist */,
+			);
+			path = BeelineTests;
+			sourceTree = "<group>";
+		};
 		22B3A5E5269DC48000E1E843 = {
 			isa = PBXGroup;
 			children = (
 				22BCBE6826A293310081CADE /* Beeline */,
-				22B3A5F0269DC48000E1E843 /* BeelineExample */,
+				227B685626A706860000DD8D /* BeelineTests */,
 				22B3A5EF269DC48000E1E843 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -52,22 +82,10 @@
 		22B3A5EF269DC48000E1E843 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				22B3A5EE269DC48000E1E843 /* BeelineExample.app */,
+				FA37C3E1297C8CBA0079E96C /* libBeeline.a */,
+				FA37C3ED297C8CFF0079E96C /* BeelineTests.xctest */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		22B3A5F0269DC48000E1E843 /* BeelineExample */ = {
-			isa = PBXGroup;
-			children = (
-				227B686026A719FA0000DD8D /* BeelineExample.entitlements */,
-				22BCBE6E26A29DCB0081CADE /* AppRouter.swift */,
-				22B3A5F1269DC48000E1E843 /* AppDelegate.swift */,
-				22BCBE7026A29F350081CADE /* ViewController.swift */,
-				22BCBE7126A29F350081CADE /* ViewController.xib */,
-				22BCBE6D26A29DAF0081CADE /* Supporting */,
-			);
-			path = BeelineExample;
 			sourceTree = "<group>";
 		};
 		22BCBE6826A293310081CADE /* Beeline */ = {
@@ -78,35 +96,43 @@
 			path = Beeline;
 			sourceTree = "<group>";
 		};
-		22BCBE6D26A29DAF0081CADE /* Supporting */ = {
-			isa = PBXGroup;
-			children = (
-				22B3A5FA269DC48100E1E843 /* Assets.xcassets */,
-				22B3A5FC269DC48100E1E843 /* LaunchScreen.storyboard */,
-				22B3A5FF269DC48100E1E843 /* Info.plist */,
-			);
-			path = Supporting;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		22B3A5ED269DC48000E1E843 /* BeelineExample */ = {
+		FA37C3E0297C8CBA0079E96C /* Beeline */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 22B3A602269DC48100E1E843 /* Build configuration list for PBXNativeTarget "BeelineExample" */;
+			buildConfigurationList = FA37C3E5297C8CBB0079E96C /* Build configuration list for PBXNativeTarget "Beeline" */;
 			buildPhases = (
-				22B3A5EA269DC48000E1E843 /* Sources */,
-				22B3A5EB269DC48000E1E843 /* Frameworks */,
-				22B3A5EC269DC48000E1E843 /* Resources */,
+				FA37C3DD297C8CBA0079E96C /* Sources */,
+				FA37C3DE297C8CBA0079E96C /* Frameworks */,
+				FA37C3DF297C8CBA0079E96C /* CopyFiles */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
-			name = BeelineExample;
-			productName = RouterTest;
-			productReference = 22B3A5EE269DC48000E1E843 /* BeelineExample.app */;
-			productType = "com.apple.product-type.application";
+			name = Beeline;
+			productName = Beeline;
+			productReference = FA37C3E1297C8CBA0079E96C /* libBeeline.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		FA37C3EC297C8CFF0079E96C /* BeelineTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FA37C3F4297C8CFF0079E96C /* Build configuration list for PBXNativeTarget "BeelineTests" */;
+			buildPhases = (
+				FA37C3E9297C8CFF0079E96C /* Sources */,
+				FA37C3EA297C8CFF0079E96C /* Frameworks */,
+				FA37C3EB297C8CFF0079E96C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				FA37C3F3297C8CFF0079E96C /* PBXTargetDependency */,
+			);
+			name = BeelineTests;
+			productName = BeelineTests;
+			productReference = FA37C3ED297C8CFF0079E96C /* BeelineTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -114,15 +140,19 @@
 		22B3A5E6269DC48000E1E843 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1250;
+				LastSwiftUpdateCheck = 1420;
 				LastUpgradeCheck = 1250;
 				TargetAttributes = {
-					22B3A5ED269DC48000E1E843 = {
-						CreatedOnToolsVersion = 12.5;
+					FA37C3E0297C8CBA0079E96C = {
+						CreatedOnToolsVersion = 14.2;
+					};
+					FA37C3EC297C8CFF0079E96C = {
+						CreatedOnToolsVersion = 14.2;
+						LastSwiftMigration = 1420;
 					};
 				};
 			};
-			buildConfigurationList = 22B3A5E9269DC48000E1E843 /* Build configuration list for PBXProject "BeelineExample" */;
+			buildConfigurationList = 22B3A5E9269DC48000E1E843 /* Build configuration list for PBXProject "Beeline" */;
 			compatibilityVersion = "Xcode 9.3";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -135,48 +165,48 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				22B3A5ED269DC48000E1E843 /* BeelineExample */,
+				FA37C3E0297C8CBA0079E96C /* Beeline */,
+				FA37C3EC297C8CFF0079E96C /* BeelineTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		22B3A5EC269DC48000E1E843 /* Resources */ = {
+		FA37C3EB297C8CFF0079E96C /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				22B3A5FE269DC48100E1E843 /* LaunchScreen.storyboard in Resources */,
-				22BCBE7326A29F350081CADE /* ViewController.xib in Resources */,
-				22B3A5FB269DC48100E1E843 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		22B3A5EA269DC48000E1E843 /* Sources */ = {
+		FA37C3DD297C8CBA0079E96C /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				22BCBE6F26A29DCB0081CADE /* AppRouter.swift in Sources */,
-				22B3A608269DCFA500E1E843 /* Router.swift in Sources */,
-				22BCBE7226A29F350081CADE /* ViewController.swift in Sources */,
-				22B3A5F2269DC48000E1E843 /* AppDelegate.swift in Sources */,
+				FA37C3E8297C8CCA0079E96C /* Router.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FA37C3E9297C8CFF0079E96C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FA37C3F8297C8D6E0079E96C /* BeelineTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
-/* Begin PBXVariantGroup section */
-		22B3A5FC269DC48100E1E843 /* LaunchScreen.storyboard */ = {
-			isa = PBXVariantGroup;
-			children = (
-				22B3A5FD269DC48100E1E843 /* Base */,
-			);
-			name = LaunchScreen.storyboard;
-			sourceTree = "<group>";
+/* Begin PBXTargetDependency section */
+		FA37C3F3297C8CFF0079E96C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = FA37C3E0297C8CBA0079E96C /* Beeline */;
+			targetProxy = FA37C3F2297C8CFF0079E96C /* PBXContainerItemProxy */;
 		};
-/* End PBXVariantGroup section */
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		22B3A600269DC48100E1E843 /* Debug */ = {
@@ -295,47 +325,76 @@
 			};
 			name = Release;
 		};
-		22B3A603269DC48100E1E843 /* Debug */ = {
+		FA37C3E6297C8CBB0079E96C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = BeelineExample/BeelineExample.entitlements;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 6LF3GMKZAB;
-				INFOPLIST_FILE = "$(SRCROOT)/BeelineExample/Supporting/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = dev.tim.BeelineTest;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTS_MACCATALYST = NO;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
-		22B3A604269DC48100E1E843 /* Release */ = {
+		FA37C3E7297C8CBB0079E96C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = BeelineExample/BeelineExample.entitlements;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 6LF3GMKZAB;
-				INFOPLIST_FILE = "$(SRCROOT)/BeelineExample/Supporting/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		FA37C3F5297C8CFF0079E96C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = dev.tim.BeelineTest;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.tim.BeelineTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTS_MACCATALYST = NO;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		FA37C3F6297C8CFF0079E96C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.tim.BeelineTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -344,7 +403,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		22B3A5E9269DC48000E1E843 /* Build configuration list for PBXProject "BeelineExample" */ = {
+		22B3A5E9269DC48000E1E843 /* Build configuration list for PBXProject "Beeline" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				22B3A600269DC48100E1E843 /* Debug */,
@@ -353,11 +412,20 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		22B3A602269DC48100E1E843 /* Build configuration list for PBXNativeTarget "BeelineExample" */ = {
+		FA37C3E5297C8CBB0079E96C /* Build configuration list for PBXNativeTarget "Beeline" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				22B3A603269DC48100E1E843 /* Debug */,
-				22B3A604269DC48100E1E843 /* Release */,
+				FA37C3E6297C8CBB0079E96C /* Debug */,
+				FA37C3E7297C8CBB0079E96C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FA37C3F4297C8CFF0079E96C /* Build configuration list for PBXNativeTarget "BeelineTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FA37C3F5297C8CFF0079E96C /* Debug */,
+				FA37C3F6297C8CFF0079E96C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Beeline.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Beeline.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:/Users/TiM/Developer/Beeline/BeelineExample.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Beeline.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Beeline.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Beeline.xcodeproj/xcshareddata/xcschemes/Beeline.xcscheme
+++ b/Beeline.xcodeproj/xcshareddata/xcschemes/Beeline.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1420"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FA37C3E0297C8CBA0079E96C"
+               BuildableName = "libBeeline.a"
+               BlueprintName = "Beeline"
+               ReferencedContainer = "container:Beeline.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FA37C3EC297C8CFF0079E96C"
+               BuildableName = "BeelineTests.xctest"
+               BlueprintName = "BeelineTests"
+               ReferencedContainer = "container:Beeline.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FA37C3E0297C8CBA0079E96C"
+            BuildableName = "libBeeline.a"
+            BlueprintName = "Beeline"
+            ReferencedContainer = "container:Beeline.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Beeline.xcodeproj/xcshareddata/xcschemes/BeelineTests.xcscheme
+++ b/Beeline.xcodeproj/xcshareddata/xcschemes/BeelineTests.xcscheme
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "227B685426A706860000DD8D"
+               BuildableName = "BeelineTests.xctest"
+               BlueprintName = "BeelineTests"
+               ReferencedContainer = "container:BeelineExample.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BeelineTests/BeelineTests.swift
+++ b/BeelineTests/BeelineTests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+@testable import Beeline
 
 // Create a dummy destination to test
 enum TestRoute: Route {

--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,12 @@ let package = Package(
     targets: [
         .target(
             name: "Beeline",
-            path: "Beeline")
+            path: "Beeline"),
+        .testTarget(
+            name: "BeelineTests",
+            dependencies: [
+                "Beeline"
+            ],
+            path: "BeelineTests")
     ]
 )


### PR DESCRIPTION
@TimOliver thanks for your great talk yesterday at [try! Swift Tokyo](https://tryswift.jp)!

Adding on top of @arasan01's PR to [add SPM support](https://github.com/TimOliver/Beeline/pull/2):

This PR adds a `.testTarget` to the package manifest.  It required me to add a testable module import to the tests which breaks building the tests inside the sample project.  So I added another project that builds Beeline as a static library and moved the tests there.  

While having this setup for a single-file library project seems a bit overkill, the tests should probably not live in the example project anyhow, but let me know what you think.